### PR TITLE
Implement thought logging with optional encryption

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 archive/PREPROMPT_HASH.txt
+archive/*.md
+archive/*.enc

--- a/scripts/run_with_thought_logger.py
+++ b/scripts/run_with_thought_logger.py
@@ -1,0 +1,23 @@
+#!/usr/bin/env python3
+import argparse
+import sys
+import runpy
+
+import thought_logger
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Run a Python module with thought logging")
+    parser.add_argument("module", help="Module to run as __main__")
+    parser.add_argument("args", nargs=argparse.REMAINDER)
+    parser.add_argument("--redact-think", action="store_true", dest="redact_think",
+                        help="Redact contents of <think> blocks in stdout/stderr")
+    args = parser.parse_args()
+
+    thought_logger.install(redact=args.redact_think)
+    sys.argv = [args.module] + args.args
+    runpy.run_module(args.module, run_name="__main__")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_thought_logger.py
+++ b/tests/test_thought_logger.py
@@ -1,0 +1,60 @@
+import sys, os; sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+import os
+import unittest
+import tempfile
+import base64
+from io import StringIO
+
+import thought_logger
+
+
+class ThoughtLoggerTests(unittest.TestCase):
+    def setUp(self):
+        self.tmpdir = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tmpdir.cleanup)
+
+    def read_log(self, encrypt=False):
+        date_str = thought_logger.datetime.now().strftime("%Y-%m-%d")
+        ext = 'enc' if encrypt else 'md'
+        path = os.path.join(self.tmpdir.name, f"THOUGHTLOG_{date_str}.{ext}")
+        with open(path, 'rb' if encrypt else 'r') as f:
+            return f.read()
+
+    def test_plain_log(self):
+        os.environ.pop('THOUGHTLOG_ENCRYPT', None)
+        out = StringIO()
+        logger = thought_logger.ThoughtLogger(out, log_dir=self.tmpdir.name)
+        logger.write("<think>secret chain</think> hello")
+        log = self.read_log(encrypt=False)
+        self.assertIn('secret chain', log)
+        self.assertTrue(out.getvalue().startswith('<think>secret chain</think>'))
+
+    def test_encrypted_roundtrip(self):
+        os.environ['THOUGHTLOG_ENCRYPT'] = '1'
+        key = b'a' * 32
+        os.environ['THOUGHTLOG_KEY'] = base64.b64encode(key).decode()
+        out = StringIO()
+        logger = thought_logger.ThoughtLogger(out, log_dir=self.tmpdir.name)
+        logger.write("<think>encrypt me</think>")
+        data = self.read_log(encrypt=True)
+        iv = data[:16]
+        cipher = thought_logger.Cipher(thought_logger.algorithms.AES(key),
+                                       thought_logger.modes.CBC(iv),
+                                       backend=thought_logger.default_backend())
+        decryptor = cipher.decryptor()
+        unpadder = thought_logger.padding.PKCS7(128).unpadder()
+        plaintext = unpadder.update(decryptor.update(data[16:]) + decryptor.finalize()) + unpadder.finalize()
+        self.assertIn('encrypt me', plaintext.decode())
+
+    def test_redact_flag(self):
+        os.environ.pop('THOUGHTLOG_ENCRYPT', None)
+        out = StringIO()
+        logger = thought_logger.ThoughtLogger(out, log_dir=self.tmpdir.name, redact=True)
+        logger.write("<think>redact this</think>")
+        log = self.read_log(encrypt=False)
+        self.assertIn('redact this', log)
+        self.assertEqual(out.getvalue().strip(), '<think>[redacted]</think>')
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/thought_logger.py
+++ b/thought_logger.py
@@ -1,0 +1,86 @@
+import os
+import re
+from datetime import datetime
+import sys
+import base64
+from typing import Optional
+
+from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes
+from cryptography.hazmat.primitives import padding
+from cryptography.hazmat.backends import default_backend
+
+
+class ThoughtLogger:
+    """Intercepts writes to a stream, logging <think>...</think> blocks."""
+
+    def __init__(self, stream, module: str = "main", redact: bool = False, log_dir: str = "archive"):
+        self.stream = stream
+        self.module = module
+        self.redact = redact
+        self.log_dir = log_dir
+        self.encrypt = os.getenv("THOUGHTLOG_ENCRYPT") == "1"
+        key_b64 = os.getenv("THOUGHTLOG_KEY")
+        if self.encrypt:
+            if key_b64:
+                self.key = base64.b64decode(key_b64)
+            else:
+                # fallback deterministic key for tests/demo (32 bytes)
+                self.key = b"0" * 32
+        else:
+            self.key = None
+        os.makedirs(self.log_dir, exist_ok=True)
+
+    def _log_path(self) -> str:
+        date_str = datetime.now().strftime("%Y-%m-%d")
+        ext = "enc" if self.encrypt else "md"
+        return os.path.join(self.log_dir, f"THOUGHTLOG_{date_str}.{ext}")
+
+    def _encrypt(self, plaintext: str) -> bytes:
+        iv = os.urandom(16)
+        cipher = Cipher(algorithms.AES(self.key), modes.CBC(iv), backend=default_backend())
+        encryptor = cipher.encryptor()
+        padder = padding.PKCS7(128).padder()
+        padded = padder.update(plaintext.encode("utf-8")) + padder.finalize()
+        ciphertext = encryptor.update(padded) + encryptor.finalize()
+        return iv + ciphertext
+
+    def _append_log(self, text: str) -> None:
+        timestamp = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+        line = f"{timestamp} [{self.module}] {text}\n"
+        path = self._log_path()
+        if self.encrypt:
+            data = self._encrypt(line)
+            mode = "ab"
+            with open(path, mode) as f:
+                f.write(data)
+        else:
+            with open(path, "a", encoding="utf-8") as f:
+                f.write(line)
+
+    def write(self, text: str) -> None:
+        pattern = re.compile(r"<think>(.*?)</think>", re.DOTALL)
+        pos = 0
+        output_parts = []
+        for match in pattern.finditer(text):
+            start, end = match.span()
+            output_parts.append(text[pos:start])
+            inner = match.group(1)
+            self._append_log(inner)
+            if self.redact:
+                output_parts.append("<think>[redacted]</think>")
+            else:
+                output_parts.append(match.group(0))
+            pos = end
+        output_parts.append(text[pos:])
+        output = "".join(output_parts)
+        self.stream.write(output)
+        self.stream.flush()
+
+    def flush(self) -> None:
+        self.stream.flush()
+
+
+def install(redact: bool = False, module: str = "main", log_dir: str = "archive") -> None:
+    """Install thought logging on stdout and stderr."""
+    sys.stdout = ThoughtLogger(sys.stdout, module=module, redact=redact, log_dir=log_dir)
+    sys.stderr = ThoughtLogger(sys.stderr, module=module, redact=redact, log_dir=log_dir)


### PR DESCRIPTION
## Summary
- add `thought_logger.py` middleware to capture `<think>` blocks
- add CLI wrapper to enable redaction
- ignore thought log files
- add unit tests for plain, encrypted, and redacted logging

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68544a6448e4832a918404442d3d887e